### PR TITLE
240827 장바구니 모달창 수정, 삭제 모달창 생성

### DIFF
--- a/JJJ-Web/src/components/ModalCart.tsx
+++ b/JJJ-Web/src/components/ModalCart.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@mui/material';
+import styles from '../styles/components/CartModal.module.css';
+
+interface ModalCartProps {
+  isOpen: boolean;
+  handleCloseModal: () => void;
+  cartModalStyles: {
+    left: number;
+    top: number;
+  };
+}
+export function ModalCart({
+  isOpen,
+  handleCloseModal,
+  cartModalStyles,
+}: ModalCartProps) {
+  if (!isOpen) return null;
+  setTimeout(() => {
+    handleCloseModal();
+  }, 3000);
+
+  return (
+    <div
+      id='modal'
+      className={styles.modal__overlay}
+      onClick={handleCloseModal}
+    >
+      <div className={styles.modal} style={cartModalStyles}>
+        <div
+          className={styles.modal__content}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <h2>장바구니에 담겼습니다</h2>
+          <Button onClick={handleCloseModal} sx={{ padding: '5px 10px' }}>
+            닫기
+          </Button>
+        </div>
+        <div className={styles.arrow}></div>
+      </div>
+    </div>
+  );
+}

--- a/JJJ-Web/src/components/ModalIsDelete.tsx
+++ b/JJJ-Web/src/components/ModalIsDelete.tsx
@@ -1,0 +1,60 @@
+import { Modal, Box, Button, Typography } from '@mui/material';
+
+interface ModalIsDeleteProps {
+  isOpen: boolean;
+  handleCloseModal: () => void;
+}
+
+const modalStyle = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  borderRadius: 'var(--border-radius)',
+  boxShadow: 24,
+  p: 4,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+};
+
+export default function ModalIsDelete({
+  isOpen,
+  handleCloseModal,
+}: ModalIsDeleteProps) {
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleCloseModal}
+      aria-labelledby='modal-modal-title'
+      aria-describedby='modal-modal-description'
+    >
+      <Box component='form' noValidate autoComplete='off' sx={modalStyle}>
+        <Typography id='modal-modal-title' variant='h6' component='h2'>
+          정말로 삭제하시겠습니까?
+        </Typography>
+        <Typography
+          id='modal-modal-description'
+          sx={{ my: 2, color: 'var(--color-red)' }}
+        >
+          삭제 후 되돌릴 수 없습니다
+        </Typography>
+
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Button onClick={handleCloseModal} sx={{ marginRight: '20px' }}>
+            삭제
+          </Button>
+          <Button onClick={handleCloseModal}>취소</Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/JJJ-Web/src/hooks/useOpenModal.tsx
+++ b/JJJ-Web/src/hooks/useOpenModal.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export function useOpenModal() {
+  const [isOpen, setModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
+  return { isOpen, handleOpenModal, handleCloseModal };
+}

--- a/JJJ-Web/src/pages/OrderedList.tsx
+++ b/JJJ-Web/src/pages/OrderedList.tsx
@@ -15,6 +15,8 @@ import React, { useState } from 'react';
 import { useInput } from '../hooks/useInput';
 import { useInputFile } from '../hooks/useInputfile';
 import AddAPhotoIcon from '@mui/icons-material/AddAPhoto';
+import { useOpenModal } from '../hooks/useOpenModal';
+import { ModalCart } from '../components/ModalCart';
 export default function OrderedList() {
   const { value, handleInputChange, reset } = useInput('');
   return (
@@ -52,7 +54,9 @@ export default function OrderedList() {
 const Orders = () => {
   return (
     <div className={styles.orders}>
-      <div className={styles.order__number}>주문번호 : 1111111 (20204. 08. 23. 17:39 결제) / 총 결제금액 : 00000원</div>
+      <div className={styles.order__number}>
+        주문번호 : 1111111 (20204. 08. 23. 17:39 결제) / 총 결제금액 : 00000원
+      </div>
       <Order />
       <Order />
       <Order />
@@ -78,6 +82,10 @@ const Order = () => {
 
   const [valueStars, setValueStars] = useState<number | null>(5);
 
+  // 장바구니 모달
+  const { isOpen, handleOpenModal, handleCloseModal } = useOpenModal();
+  const customPosition = { left: 55, top: 10 };
+
   return (
     <div className={styles.order__container}>
       <div className={styles.order__img}>
@@ -90,9 +98,14 @@ const Order = () => {
         <p>총 상품금액 : 10000원</p>
       </div>
       <div className={styles.order__buttons}>
-        <Button onClick={() => navigate('/cart')} sx={{ marginBottom: '20px' }}>
+        <Button onClick={handleOpenModal} sx={{ marginBottom: '20px' }}>
           장바구니
         </Button>
+        <ModalCart
+          isOpen={isOpen}
+          handleCloseModal={handleCloseModal}
+          cartModalStyles={customPosition}
+        />
         <React.Fragment>
           <Button onClick={handleOpen}>리뷰작성</Button>
           <Modal
@@ -177,7 +190,7 @@ function UploadInput() {
       <div>
         <label role='button' htmlFor='file' className={styles.label__button}>
           <AddAPhotoIcon />
-          이미지 등록 : 최대 5개
+          <span className={styles.label__span}>이미지 등록 : 최대 5개</span>
         </label>
         <input
           id='file'

--- a/JJJ-Web/src/pages/Payment.tsx
+++ b/JJJ-Web/src/pages/Payment.tsx
@@ -355,7 +355,7 @@ export default function Payment() {
       </form>
 
       <footer
-        style={{ marginBottom: '50px', marginTop: '100px', width: '100%' }}
+        style={{ marginBottom: '50px', marginTop: '50px', width: '100%' }}
       >
         <Footer />
       </footer>

--- a/JJJ-Web/src/pages/ProductDetail.tsx
+++ b/JJJ-Web/src/pages/ProductDetail.tsx
@@ -4,6 +4,7 @@ import styles from '../styles/pages/ProductDetail.module.css';
 import StarRateIcon from '@mui/icons-material/StarRate';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
+import ClearIcon from '@mui/icons-material/Clear';
 import Button from '@mui/material/Button';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -27,7 +28,9 @@ import desc01 from '../assets/images/productDescription/desc01.jpeg';
 import desc02 from '../assets/images/productDescription/desc02.jpeg';
 import desc03 from '../assets/images/productDescription/desc03.jpeg';
 import desc04 from '../assets/images/productDescription/desc04.jpeg';
-
+import { useOpenModal } from '../hooks/useOpenModal';
+import { ModalCart } from '../components/ModalCart';
+import ModalIsDelete from '../components/ModalIsDelete';
 const images = [img01, img02, img03, img04, img05];
 
 export default function ProductDetail() {
@@ -68,15 +71,8 @@ export default function ProductDetail() {
   };
 
   // 장바구니 모달
-  const [isModalOpen, setModalOpen] = useState(false);
-
-  const handleAddToCart = () => {
-    setModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-  };
+  const { isOpen, handleOpenModal, handleCloseModal } = useOpenModal();
+  const customPosition = { left: 23, top: -10 };
 
   return (
     <div className='flex__container'>
@@ -136,18 +132,19 @@ export default function ProductDetail() {
                 </IconButton>
               </Box>
               <div className={styles.actions__container}>
+                {/* 장바구니 모달 */}
+                <ModalCart
+                  isOpen={isOpen}
+                  handleCloseModal={handleCloseModal}
+                  cartModalStyles={customPosition}
+                />
                 <IconButton
                   className='round nest__icons'
-                  onClick={handleAddToCart}
+                  onClick={handleOpenModal}
                   sx={{
                     marginRight: '20px',
                   }}
                 >
-                  {/* 장바구니 모달 */}
-                  <CartModal
-                    isOpen={isModalOpen}
-                    handleCloseModal={handleCloseModal}
-                  />
                   <ShoppingCartOutlinedIcon className='default font__large' />
                   <ShoppingCartIcon className='show font__large' />
                 </IconButton>
@@ -175,32 +172,6 @@ export default function ProductDetail() {
         <DetailTab />
       </div>
       <Footer />
-    </div>
-  );
-}
-
-// 장바구니 - 모달창 만들어야함
-interface CartModalProps {
-  isOpen: boolean;
-  handleCloseModal: () => void;
-}
-export function CartModal({ isOpen, handleCloseModal }: CartModalProps) {
-  if (!isOpen) return null;
-
-  return (
-    <div className={styles.modal__overlay} onClick={handleCloseModal}>
-      <div className={styles.modal}>
-        <div
-          className={styles.modal__content}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <h2>장바구니에 담겼습니다</h2>
-          <Button onClick={handleCloseModal} sx={{ padding: '5px 10px' }}>
-            닫기
-          </Button>
-        </div>
-        <div className={styles.arrow}></div>
-      </div>
     </div>
   );
 }
@@ -261,12 +232,82 @@ function DetailTab() {
       </CustomTabPanel>
 
       <CustomTabPanel value={value} index={1}>
-        <Box>하하</Box>
+        <Box sx={{ width: '100%' }}>
+          <Review />
+          <Review />
+          <Review />
+          {/* 리뷰가 없을 때 */}
+          {/* <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            등록된 리뷰가 없습니다.
+          </Box> */}
+        </Box>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
-        <Box>하하</Box>
+        <Box sx={{ width: '100%' }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            등록된 문의가 없습니다.
+          </Box>
+        </Box>
       </CustomTabPanel>
     </Box>
+  );
+}
+
+function Review() {
+  const userId = 'userId1234';
+  // 로그인된 사용자의 리뷰에만 삭제 버튼이 보이도록 해야 함
+
+  // 삭제 모달
+  const isDelete = useOpenModal();
+
+  return (
+    <div className={styles.review}>
+      <div className={styles.review__id}>
+        <div>{userId}</div>
+        {userId && (
+          <IconButton
+            onClick={isDelete.handleOpenModal}
+            sx={{ padding: '5px' }}
+          >
+            <ClearIcon sx={{ fontSize: 'var(--font-size-regular)' }} />
+          </IconButton>
+        )}
+        <ModalIsDelete
+          isOpen={isDelete.isOpen}
+          handleCloseModal={isDelete.handleCloseModal}
+        />
+      </div>
+      <div className={styles.star__date__container}>
+        <div className={styles.stars}>
+          {[...Array(5)].map((_, index) => (
+            <StarRateIcon
+              key={index}
+              fontSize='small'
+              sx={{
+                margin: '0 -1.4px',
+                color:
+                  index < 4 ? 'var(--color-orange)' : 'var(--color-blue-light)',
+              }}
+            />
+          ))}
+        </div>
+        <div>{new Date().toLocaleDateString()}</div>
+      </div>
+      {images && (
+        <div className={styles.review__img__container}>
+          {images.map((image) => (
+            <img src={image} alt='이미지' />
+          ))}
+        </div>
+      )}
+      <div className={styles.review__description}>
+        이 장난감은 정말 대단한 발견이에요! 잘 만들어졌고, 다채롭고, 아이들에게
+        안전합니다. 우리 아이는 그것을 정말 좋아하고 몇 시간 동안 계속
+        참여합니다. <br />
+        소재는 내구성이 뛰어나고 디자인은 세심해서 걱정할 작은 부품이 없습니다.
+        창의성을 장려하고 청소가 쉽습니다. 활동적인 플레이에 적극 추천합니다!
+      </div>
+    </div>
   );
 }
 
@@ -288,7 +329,9 @@ function CustomTabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ pt: 3, display: 'flex', flexWrap: 'wrap' }}>{children}</Box>
+        <Box sx={{ paddingTop: '50px', display: 'flex', flexWrap: 'wrap' }}>
+          {children}
+        </Box>
       )}
     </div>
   );

--- a/JJJ-Web/src/pages/UsedProductList.tsx
+++ b/JJJ-Web/src/pages/UsedProductList.tsx
@@ -13,9 +13,11 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import useActiveState from '../hooks/useActiveState';
 import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
-import { CartModal } from './ProductDetail';
 import ImageTab from '../components/ImageTab';
-
+import { ModalCart } from '../components/ModalCart';
+import { useOpenModal } from '../hooks/useOpenModal';
+import ClearIcon from '@mui/icons-material/Clear';
+import ModalIsDelete from '../components/ModalIsDelete';
 export default function UsedProductList() {
   const navigate = useNavigate();
   const [products, setProducts] = useState<UsedProductProp[]>([]);
@@ -67,15 +69,11 @@ function UsedProduct({
     useActiveState(false);
   const navigate = useNavigate();
   // 장바구니 모달
-  const [isModalOpen, setModalOpen] = useState(false);
+  const { isOpen, handleOpenModal, handleCloseModal } = useOpenModal();
+  const customPosition = { left: 18, top: -9 };
 
-  const handleAddToCart = () => {
-    setModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-  };
+  // 삭제 모달
+  const isDelete = useOpenModal();
 
   // 이미지탭 커스텀 CSS
   const customImageTabStyles = {
@@ -94,6 +92,8 @@ function UsedProduct({
     setCurrentImg(value.src);
   };
 
+  const userId = 'userId1234';
+
   return (
     <div className={styles.item__container} onClick={onClick}>
       <ImageTab
@@ -105,7 +105,21 @@ function UsedProduct({
       <div className={styles.item__descriptions}>
         <div className={styles.item__infos}>
           <div className={styles.info__container}>
-            <div className={styles.item__user}>userId</div>
+            <div className={styles.item__user}>
+              <div>{userId}</div>
+              {userId && (
+                <IconButton
+                  onClick={isDelete.handleOpenModal}
+                  sx={{ padding: '2px' }}
+                >
+                  <ClearIcon sx={{ fontSize: 'var(--font-size-regular)' }} />
+                </IconButton>
+              )}
+              <ModalIsDelete
+                isOpen={isDelete.isOpen}
+                handleCloseModal={isDelete.handleCloseModal}
+              />
+            </div>
             <div className={styles.item__title}>{usedTitle}</div>
             <div className={styles.item__price}>
               {usedPrice.toLocaleString()}원
@@ -118,18 +132,19 @@ function UsedProduct({
             </div>
           </div>
           <div className={styles.btn__box}>
+            {/* 장바구니 모달 */}
+            <ModalCart
+              isOpen={isOpen}
+              handleCloseModal={handleCloseModal}
+              cartModalStyles={customPosition}
+            />
             <IconButton
               className='round nest__icons'
-              onClick={handleAddToCart}
+              onClick={handleOpenModal}
               sx={{
                 marginRight: '20px',
               }}
             >
-              {/* 장바구니 모달 */}
-              <CartModal
-                isOpen={isModalOpen}
-                handleCloseModal={handleCloseModal}
-              />
               <ShoppingCartOutlinedIcon className='default font__medium' />
               <ShoppingCartIcon className='show font__medium' />
             </IconButton>

--- a/JJJ-Web/src/styles/components/BestProducts.module.css
+++ b/JJJ-Web/src/styles/components/BestProducts.module.css
@@ -1,6 +1,6 @@
 .best__product {
   width: var(--max-width);
-  margin: 50px 0px 25px;
+  margin-top: 50px;
 }
 
 /* .best__product__title {

--- a/JJJ-Web/src/styles/components/CartModal.module.css
+++ b/JJJ-Web/src/styles/components/CartModal.module.css
@@ -1,0 +1,42 @@
+.modal__overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 5;
+}
+
+.modal {
+  width: 220px;
+  position: absolute;
+  /* left와 top은 tsx에서 변수로 받아옴 */
+  /* left: 23px; */
+  /* top: -10px; */
+  background: var(--color-white);
+  transform: translate(-50%, -100%);
+  padding: 10px 20px;
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  text-align: center;
+}
+
+.modal__content {
+  color: var(--color-black);
+  padding: 10px;
+}
+
+.modal__content h2 {
+  font-size: var(--font-size-regular);
+  margin-bottom: 16px;
+}
+
+.arrow {
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid var(--color-white);
+}

--- a/JJJ-Web/src/styles/components/Product.module.css
+++ b/JJJ-Web/src/styles/components/Product.module.css
@@ -10,6 +10,10 @@
   margin-right: 0;
 }
 
+.item__container:last-of-type {
+  margin-bottom: 50px;
+}
+
 .item__img {
   width: 100%;
   height: 246px;

--- a/JJJ-Web/src/styles/pages/OrderedList.module.css
+++ b/JJJ-Web/src/styles/pages/OrderedList.module.css
@@ -24,7 +24,6 @@
   box-shadow: var(--box-shadow);
   height: 150px;
   gap: 20px;
-  overflow: hidden;
   margin-bottom: 20px;
 }
 
@@ -63,6 +62,7 @@
 
 .order__buttons {
   flex: 0.5;
+  position: relative;
 }
 
 /* 모달 */
@@ -173,12 +173,17 @@
   user-select: none;
   width: 250px;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
 }
 
 .label__button:hover {
   color: var(--color-white);
   background-color: var(--color-blue);
+}
+
+.label__span {
+  margin-bottom: 1px;
+  margin-left: 5px;
 }
 
 .preview__container {

--- a/JJJ-Web/src/styles/pages/OrderedList.module.css
+++ b/JJJ-Web/src/styles/pages/OrderedList.module.css
@@ -11,6 +11,10 @@
   margin-bottom: 30px;
 }
 
+.orders:last-of-type {
+  margin-bottom: 50px;
+}
+
 .order__number {
   margin: 5px 0 20px 5px;
   color: var(--color-black);

--- a/JJJ-Web/src/styles/pages/Payment.module.css
+++ b/JJJ-Web/src/styles/pages/Payment.module.css
@@ -1,12 +1,7 @@
 /* 신승주 */
 
-/* 변지윤 */
-
 .form__payment {
   /* width: var(--max-width); */
-}
-
-.relative {
 }
 
 .info__title {
@@ -24,6 +19,10 @@
   padding: 30px 0;
   align-items: center;
   width: 705px;
+}
+
+.info__container:last-of-type {
+  padding-bottom: 0;
 }
 
 .address__container {

--- a/JJJ-Web/src/styles/pages/ProductDetail.module.css
+++ b/JJJ-Web/src/styles/pages/ProductDetail.module.css
@@ -52,48 +52,41 @@
 }
 
 .actions__container {
+  position: relative;
   display: flex;
   align-items: center;
 }
 
-/* ModalCart */
-.modal__overlay {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  z-index: 5;
+/* Review CSS */
+.review {
+  width: 100%;
+  border-bottom: 1px solid var(--color-grey-light);
+  padding: 50px 0;
 }
 
-.modal {
-  position: absolute;
-  left: 23px;
-  top: -10px;
-  background: var(--color-white);
-  transform: translate(-50%, -100%);
-  padding: 10px 20px;
-  border-radius: var(--border-radius);
-  box-shadow: var(--box-shadow);
-  text-align: center;
+.review:first-child {
+  padding-top: 0;
 }
 
-.modal__content {
-  color: var(--color-black);
-  padding: 10px;
+.review__id {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.modal__content h2 {
-  font-size: var(--font-size-regular);
-  margin-bottom: 16px;
+.star__date__container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
 }
 
-.arrow {
-  position: absolute;
-  bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-top: 10px solid var(--color-white);
+.review__img__container {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.review__img__container img {
+  width: 115px;
+  height: 80px;
+  object-fit: cover;
 }

--- a/JJJ-Web/src/styles/pages/ProductList.module.css
+++ b/JJJ-Web/src/styles/pages/ProductList.module.css
@@ -23,7 +23,7 @@
 
 .no__product {
   font-size: var(--font-size-medium);
-  margin: 30px auto;
+  margin: 50px auto;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/JJJ-Web/src/styles/pages/UsedProductList.module.css
+++ b/JJJ-Web/src/styles/pages/UsedProductList.module.css
@@ -38,8 +38,10 @@
 }
 
 .item__user {
-  padding-top: 3px;
   font-size: var(--font-size-small);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
 }
 
 .item__title {
@@ -49,6 +51,9 @@
 .item__infos {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  height: 306px;
 }
 
 .info__container {
@@ -71,10 +76,11 @@
 }
 
 .btn__box {
-  height: 60px;
+  /* height: 60px; */
   display: flex;
-  justify-content: flex-end;
-  align-items: flex-end;
+  /* justify-content: flex-end; */
+  /* align-items: flex-end; */
+  position: relative;
 }
 
 /* ImageTab.module.css 에서의 커스텀*/

--- a/JJJ-Web/src/styles/pages/UsedProductList.module.css
+++ b/JJJ-Web/src/styles/pages/UsedProductList.module.css
@@ -18,6 +18,10 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
+.item__container:last-of-type {
+  margin-bottom: 50px;
+}
+
 .item__thumb__img {
   width: 50%;
   height: 246px;

--- a/JJJ-Web/src/styles/theme.ts
+++ b/JJJ-Web/src/styles/theme.ts
@@ -141,7 +141,6 @@ export const theme = createTheme({
             borderRadius: '50%',
           },
           '&.nest__icons': {
-            position: 'relative',
             '& .MuiSvgIcon-root': {
               '&.font__large': {
                 fontSize: '30px',


### PR DESCRIPTION
디테일페이지, 중고상품페이지, 주문내역페이지
장바구니 모달창 위치 UI 수정 완료
장바구니 모달창은 3초뒤에 자동으로 닫히게 하는 기능 추가
장바구니 모달창에 hover했을 때 버튼이 hover되는거 방지 
장바구니 모달창을 ModalCart.tsx 라는 컴포넌트로 분리
OrderedList.tsx, ProductDetail.tsx, UsedProductList.tsx 에서 import해서 활용중
모달창 상태관리를 많이 반복해서 - useOpenModal 훅 만들었음

마이페이지 - 주문내역
이미지 등록 UI 가운데 정렬 완료

디테일페이지
상품 리뷰 UI 완료
상품 리뷰에 삭제 버튼 추가
Q & A UI 완료

예정에 없었는데 만든것
ModalIsDelete.tsx 컴포넌트 생성
삭제버튼 누르면, 정말로 삭제하시겠습니까? 나오는 모달창 컴포넌트 완료
어디서든 import만 하면 바로 재활용 가능
적용해본 페이지 -> 디테일페이지의 리뷰작성, 중고상품리스트 페이지에서 내가 올린 상품 삭제
적용해보면 좋을것 같은 페이지 (삭제 버튼을 제공하는 모든페이지)
주문내역, 찜목록, 나의중고상품, 장바구니 


아래 페이지들 푸터와의 마진 50px로 통일작업완료
홈, 카테고리 페이지, 중고상품리스트, 검색, 주문내역, 결제페이지
디테일페이지 (상품 설명칸은 여백50px 하기 어려움 - 이미지 자체 하단에 공백이 많음, 어쩔수 없는 부분인듯)